### PR TITLE
Cleanup Error Handling in ConditionType Derive Proc Macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "knative"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "k8s-openapi",
@@ -516,6 +516,7 @@ name = "knative-derive"
 version = "0.1.0"
 dependencies = [
  "knative-conditions",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ async fn reconcile(my_resource: Arc<MySource>, ctx: Context<Data>) -> Result<Act
         // ...patch the new status with the api
     }
 
-    Ok(Action::requeue(std::time::Duration::from_secs( 60 * 60)))
+    Ok(Action::requeue(std::time::Duration::from_secs(60 * 60)))
 }
 ```
 
-Additionaly reference usage of this crate is currently WIP!
+Additional reference usage of this crate is currently WIP!
 
 [knative]: https://knative.dev/docs/
 [keventing]: https://github.com/knative/eventing

--- a/knative-derive/Cargo.toml
+++ b/knative-derive/Cargo.toml
@@ -18,3 +18,4 @@ path = "tests/test.rs"
 quote = "1.0.20"
 syn = { version = "1.0.98", features = ["extra-traits"] }
 knative-conditions = { path = "../knative-conditions", version = "0.1.0" }
+proc-macro2 = "1.0.42"

--- a/knative-derive/src/error.rs
+++ b/knative-derive/src/error.rs
@@ -1,0 +1,30 @@
+use crate::REQUIRED_VARIANTS;
+use proc_macro2::Span;
+use syn::Error;
+use std::fmt;
+
+pub enum VerificationError {
+    NotDependent(String),
+    OneRequiredVariant,
+}
+
+impl fmt::Display for VerificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use VerificationError::*;
+        match self {
+            NotDependent(s) => f.write_fmt(format_args!("{} may not be a dependent", s)),
+            OneRequiredVariant => f.write_fmt(
+                format_args!(
+                    "ConditionType must contain only one of either {} variant",
+                    REQUIRED_VARIANTS.join(" or ")
+                )
+            )
+        }
+    }
+}
+
+impl From<VerificationError> for Error {
+    fn from(v: VerificationError) -> Error {
+        Error::new(Span::call_site(), v)
+    }
+}

--- a/knative-derive/src/inner.rs
+++ b/knative-derive/src/inner.rs
@@ -1,5 +1,8 @@
+use crate::{
+    REQUIRED_VARIANTS,
+    error::VerificationError
+};
 use proc_macro::TokenStream;
-use proc_macro2::Span;
 use quote::quote;
 use syn::{
     spanned::Spanned,
@@ -12,35 +15,6 @@ use syn::{
     DeriveInput,
     Ident
 };
-use std::fmt;
-
-const REQUIRED_VARIANTS: [&str; 2] = ["Ready", "Succeeded"];
-
-enum VerificationError {
-    NotDependent(String),
-    OneRequiredVariant,
-}
-
-impl fmt::Display for VerificationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use VerificationError::*;
-        match self {
-            NotDependent(s) => f.write_fmt(format_args!("{} may not be a dependent", s)),
-            OneRequiredVariant => f.write_fmt(
-                format_args!(
-                    "ConditionType must contain only one of either {} variant",
-                    REQUIRED_VARIANTS.join(" or ")
-                )
-            )
-        }
-    }
-}
-
-impl From<VerificationError> for Error {
-    fn from(v: VerificationError) -> Error {
-        Error::new(Span::call_site(), v)
-    }
-}
 
 fn is_dependent(variant: &syn::Variant) -> bool {
     variant.attrs

--- a/knative-derive/src/inner.rs
+++ b/knative-derive/src/inner.rs
@@ -1,0 +1,174 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{
+    spanned::Spanned,
+    punctuated::Punctuated,
+    token::Comma,
+    Variant,
+    Error,
+    Result,
+    Data::Enum,
+    DeriveInput,
+    Ident
+};
+use std::fmt;
+
+const REQUIRED_VARIANTS: [&str; 2] = ["Ready", "Succeeded"];
+
+enum VerificationError {
+    NotDependent(String),
+    OneRequiredVariant,
+}
+
+impl fmt::Display for VerificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use VerificationError::*;
+        match self {
+            NotDependent(s) => f.write_fmt(format_args!("{} may not be a dependent", s)),
+            OneRequiredVariant => f.write_fmt(
+                format_args!(
+                    "ConditionType must contain only one of either {} variant",
+                    REQUIRED_VARIANTS.join(" or ")
+                )
+            )
+        }
+    }
+}
+
+impl From<VerificationError> for Error {
+    fn from(v: VerificationError) -> Error {
+        Error::new(Span::call_site(), v)
+    }
+}
+
+fn is_dependent(variant: &syn::Variant) -> bool {
+    variant.attrs
+        .iter()
+        .any(|a| a.path.segments.iter()
+             .any(|p| p.ident == "dependent"))
+}
+
+fn verify_variants(variants: &Punctuated<Variant, Comma>) -> Result<()> {
+    let mut one_required = false;
+
+    for v in variants {
+        let name = v.ident.to_string();
+        if REQUIRED_VARIANTS.contains(&name.as_str()) {
+            // Ensure top level conditions are not dependents
+            if is_dependent(&v) {
+                Err(VerificationError::NotDependent(name))?
+            }
+            // Ensure only one top level condition exists
+            if !one_required {
+                one_required = true;
+            } else {
+                Err(VerificationError::OneRequiredVariant)?
+            }
+        }
+    }
+
+    if !one_required {
+        Err(VerificationError::OneRequiredVariant)?
+    }
+
+    Ok(())
+}
+
+pub fn inner_derive(ast: DeriveInput) -> Result<TokenStream> {
+    let name = &ast.ident;
+
+    let variants = match ast.data {
+        Enum(syn::DataEnum { ref variants, .. }) => variants,
+        _ => return Err(Error::new(
+            ast.span(),
+            "ConditionType may only be derived on enums"
+        ))
+    };
+
+    verify_variants(variants)?;
+
+    let happy = &variants.iter()
+        .find(|v| REQUIRED_VARIANTS.contains(&v.ident.to_string().as_str()))
+        .unwrap()
+        .ident;
+    let dependents = variants.iter()
+        .filter(|v| is_dependent(v))
+        .map(|v| &v.ident);
+
+    let capitalized = variants.iter()
+        .map(|v| v.ident.clone())
+        .filter(|v| !REQUIRED_VARIANTS.contains(&v.to_string().as_str()));
+    let lower_case = capitalized.clone()
+        .map(|v| Ident::new(&v.to_string().to_lowercase(), v.span()));
+    let lower_case_doc = capitalized.clone()
+        .map(|c| format!("Returns the `{c}` variant of the [`ConditionType`]"));
+    let lower_case_again = lower_case.clone();
+    let lower_case_again_again = lower_case.clone();
+
+    let mark = lower_case.clone().map(|l| Ident::new(&format!("mark_{l}"), l.span()));
+    let mark_with_reason = lower_case.clone().map(|l| Ident::new(&format!("mark_{l}_with_reason"), l.span()));
+    let mark_not = lower_case.clone().map(|l| Ident::new(&format!("mark_not_{l}"), l.span()));
+
+    let condition_type_name = Ident::new(&format!("{name}Type"), name.span());
+    let condition_type_doc = format!("A [`ConditionType`] that implement this trait duck types to [`{name}`].");
+    let manager_name = Ident::new(&format!("{name}Manager"), name.span());
+    let manager_doc = format!("Allows a status to manage [`{name}`].");
+
+    Ok(quote! {
+        #[doc = #condition_type_doc]
+        pub trait #condition_type_name: ::knative_conditions::ConditionType {
+            #(
+                #[doc = #lower_case_doc]
+                fn #lower_case() -> Self;
+            )*
+        }
+
+        #[automatically_derived]
+        impl #condition_type_name for #name {
+            #(
+                fn #lower_case_again() -> Self {
+                    #name::#capitalized
+                }
+            )*
+        }
+
+        #[automatically_derived]
+        impl ::knative_conditions::ConditionType for #name {
+            fn happy() -> Self {
+                #name::#happy
+            }
+
+            fn dependents() -> &'static [Self] {
+                &[#(#name::#dependents),*]
+            }
+        }
+
+        #[automatically_derived]
+        impl Default for #name {
+            fn default() -> Self {
+                #name::#happy
+            }
+        }
+
+        #[doc = #manager_doc]
+        pub trait #manager_name<S>: ::knative_conditions::ConditionAccessor<S>
+        where S: #condition_type_name {
+            #(
+                fn #mark(&mut self) {
+                    self.manager().mark_true(S::#lower_case_again_again());
+                }
+
+                fn #mark_with_reason(&mut self, reason: &str, message: Option<String>) {
+                    self.manager().mark_true_with_reason(S::#lower_case_again_again(), reason, message);
+                }
+
+                fn #mark_not(&mut self, reason: &str, message: Option<String>) {
+                    self.manager().mark_false(S::#lower_case_again_again(), reason, message);
+                }
+            )*
+        }
+
+        impl<S: #condition_type_name, T: ::knative_conditions::ConditionAccessor<S> + ?Sized> #manager_name<S> for T {}
+    }.into())
+}

--- a/knative-derive/src/lib.rs
+++ b/knative-derive/src/lib.rs
@@ -1,10 +1,9 @@
+mod inner;
+
 use proc_macro::TokenStream;
-use quote::quote;
 use syn::{
     parse_macro_input,
-    Data::Enum,
     DeriveInput,
-    Ident
 };
 
 /// Derive [`knative_conditions::ConditionType`] on your own `enum` to adhere to the Knative Source schema and condition
@@ -33,107 +32,10 @@ use syn::{
 /// ```
 #[proc_macro_derive(ConditionType, attributes(dependent))]
 pub fn derive(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
+    let ast: DeriveInput = parse_macro_input!(input);
 
-    let name = &ast.ident;
-    let variants = match ast.data {
-        Enum(syn::DataEnum { ref variants, .. }) => variants,
-        _ => panic!("ConditionType may only be derived on enums")
-    };
-
-    let required_variants = ["Ready", "Succeeded"];
-    let dependents = variants.clone().into_iter()
-        .filter(|v| v.attrs.iter().any(|a| a.path.segments.iter().any(|p| p.ident == "dependent")))
-        .map(|v| v.ident);
-    let dependents_again = dependents.clone();
-
-    let variant_strings: Vec<String> = variants.iter().map(|v| v.ident.to_string()).collect();
-    let dependent_strings: Vec<String> = dependents.clone().map(|d| d.to_string()).collect();
-
-    if let Some(required) = dependent_strings.iter().find(|d| required_variants.contains(&d.as_str())) {
-         panic!("{} variant may not be a dependent", required)
+    match inner::inner_derive(ast) {
+        Ok(v) => v,
+        Err(e) => e.to_compile_error().into()
     }
-
-    // check if both happy variants exist on the enum
-    if required_variants.iter().all(|req| variant_strings.iter().any(|v| v == *req)) {
-         panic!("ConditionType may only contain one of either Ready or Succeeded variants")
-    }
-
-    let happy = variants.iter().find(|v| required_variants.contains(&v.ident.to_string().as_str()))
-            .expect("ConditionType must contain either Ready or Succeeded variant");
-    let capitalized = variants.iter()
-        .map(|v| v.ident.clone())
-        .filter(|v| !required_variants.contains(&v.to_string().as_str()));
-    let lower_case = capitalized.clone()
-        .map(|v| Ident::new(&v.to_string().to_lowercase(), v.span()));
-    let lower_case_doc = capitalized.clone().map(|c| format!("Returns the `{c}` variant of the [`ConditionType`]"));
-    let lower_case_again = lower_case.clone();
-    let lower_case_again_again = lower_case.clone();
-
-    let mark = lower_case.clone().map(|l| Ident::new(&format!("mark_{l}"), l.span()));
-    let mark_with_reason = lower_case.clone().map(|l| Ident::new(&format!("mark_{l}_with_reason"), l.span()));
-    let mark_not = lower_case.clone().map(|l| Ident::new(&format!("mark_not_{l}"), l.span()));
-
-    let condition_type_name = Ident::new(&format!("{name}Type"), name.span());
-    let condition_type_doc = format!("A [`ConditionType`] that implement this trait duck types to [`{name}`].");
-    let manager_name = Ident::new(&format!("{name}Manager"), name.span());
-    let manager_doc = format!("Allows a status to manage [`{name}`].");
-
-    quote! {
-        #[doc = #condition_type_doc]
-        pub trait #condition_type_name: ::knative_conditions::ConditionType {
-            #(
-                #[doc = #lower_case_doc]
-                fn #lower_case() -> Self;
-            )*
-        }
-
-        #[automatically_derived]
-        impl #condition_type_name for #name {
-            #(
-                fn #lower_case_again() -> Self {
-                    #name::#capitalized
-                }
-            )*
-        }
-
-        #[automatically_derived]
-        impl ::knative_conditions::ConditionType for #name {
-            fn happy() -> Self {
-                #name::#happy
-            }
-
-            fn dependents() -> &'static [Self] {
-                &[#(#name::#dependents_again),*]
-            }
-        }
-
-        #[automatically_derived]
-        impl Default for #name {
-            fn default() -> Self {
-                #name::#happy
-            }
-        }
-
-        #[doc = #manager_doc]
-        pub trait #manager_name<S>: ::knative_conditions::ConditionAccessor<S>
-        where S: #condition_type_name {
-            #(
-                fn #mark(&mut self) {
-                    self.manager().mark_true(S::#lower_case_again_again());
-                }
-
-                fn #mark_with_reason(&mut self, reason: &str, message: Option<String>) {
-                    self.manager().mark_true_with_reason(S::#lower_case_again_again(), reason, message);
-                }
-
-                fn #mark_not(&mut self, reason: &str, message: Option<String>) {
-                    self.manager().mark_false(S::#lower_case_again_again(), reason, message);
-                }
-            )*
-        }
-
-        impl<S: #condition_type_name, T: ::knative_conditions::ConditionAccessor<S> + ?Sized> #manager_name<S> for T {}
-    }.into()
 }
-

--- a/knative-derive/src/lib.rs
+++ b/knative-derive/src/lib.rs
@@ -42,3 +42,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         Err(e) => e.to_compile_error().into()
     }
 }
+
+// Shout out to @johnhoo for his excellent proc macro tutorial!
+// This probably would have been too scary to attempt without it:
+// https://youtu.be/geovSK3wMB8

--- a/knative-derive/src/lib.rs
+++ b/knative-derive/src/lib.rs
@@ -1,3 +1,4 @@
+mod error;
 mod inner;
 
 use proc_macro::TokenStream;
@@ -5,6 +6,8 @@ use syn::{
     parse_macro_input,
     DeriveInput,
 };
+
+const REQUIRED_VARIANTS: [&str; 2] = ["Ready", "Succeeded"];
 
 /// Derive [`knative_conditions::ConditionType`] on your own `enum` to adhere to the Knative Source schema and condition
 /// management.

--- a/knative/src/lib.rs
+++ b/knative/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 mod duck;
 pub mod error;
 
@@ -11,7 +12,3 @@ pub mod conditions {
 pub mod derive {
     pub use knative_derive::ConditionType;
 }
-
-#[doc = include_str!("../../README.md")]
-#[cfg(doctest)]
-pub struct ReadmeDoctests;


### PR DESCRIPTION
# Cleanup Error Handling in ConditionType Proc Macro

Uses `syn::Error` for error handling instead of panicing, making everything easier to read.

Also fixes missing crate-level docs for the `knative` crate!

- wraps a fallible `inner_derive` in the outer `derive`
- includes knative readme as crate doc
