### PR TITLE
More Condition Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Knative
 
+[![CI](https://github.com/rusty-jules/knative-rs/actions/workflows/ci.yaml/badge.svg)](https://github.com/rusty-jules/knative-rs/actions/workflows/ci.yaml)
+[![Crates.io](https://img.shields.io/crates/v/knative)](https://crates.io/crates/knative)
+
 A Rust implementation of [Knative][knative] and [Knative Eventing][keventing] custom resource defintions and objects, leveraging [kube-rs][kubers].
 
 This implementation is *incomplete* and should be considered pre-alpha. It contains only a small subset of the full specification.

--- a/knative-conditions/src/lib.rs
+++ b/knative-conditions/src/lib.rs
@@ -187,7 +187,7 @@ impl<C: ConditionType> Condition<C> {
 }
 
 /// A `Vec<Condition>` that maintains transition times.
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 pub struct Conditions<C: ConditionType>(Vec<Condition<C>>);
 
 impl<C: ConditionType> Default for Conditions<C> {

--- a/knative-conditions/src/lib.rs
+++ b/knative-conditions/src/lib.rs
@@ -158,30 +158,29 @@ impl<C: ConditionType> PartialOrd for Condition<C> {
 }
 
 impl<C: ConditionType> Condition<C> {
-    fn new(type_: C) -> Self {
+    pub fn new(type_: C) -> Self {
         Condition {
             type_,
             ..Default::default()
         }
     }
 
-    fn with_status(type_: C, status: ConditionStatus) -> Condition<C> {
+    pub fn with_status(type_: C, status: ConditionStatus) -> Condition<C> {
         Condition {
             status,
             ..Condition::new(type_)
         }
     }
 
-    fn is_true(&self) -> bool {
+    pub fn is_true(&self) -> bool {
         self.status == ConditionStatus::True
     }
 
-    fn is_false(&self) -> bool {
+    pub fn is_false(&self) -> bool {
         self.status == ConditionStatus::False
     }
 
-    #[allow(dead_code)]
-    fn is_unknown(&self) -> bool {
+    pub fn is_unknown(&self) -> bool {
         self.status == ConditionStatus::Unknown
     }
 }

--- a/knative-conditions/src/lib.rs
+++ b/knative-conditions/src/lib.rs
@@ -13,12 +13,14 @@ where Self: 'static {
     fn dependents() -> &'static [Self];
 
     /// Whether the [`ConditionType`] determines happiness.
+    #[inline]
     fn is_terminal(&self) -> bool {
         Self::dependents().contains(self) || *self == Self::happy()
     }
 
     /// A [`Condition`] severity defaults to whether it determines overall resource readiness or
     /// not.
+    #[inline]
     fn severity(&self) -> ConditionSeverity {
         if self.is_terminal() {
             ConditionSeverity::Error

--- a/knative-derive/src/inner.rs
+++ b/knative-derive/src/inner.rs
@@ -101,6 +101,7 @@ pub fn inner_derive(ast: DeriveInput) -> Result<TokenStream> {
         #[automatically_derived]
         impl #condition_type_name for #name {
             #(
+                #[inline]
                 fn #lower_case_again() -> Self {
                     #name::#capitalized
                 }
@@ -109,10 +110,12 @@ pub fn inner_derive(ast: DeriveInput) -> Result<TokenStream> {
 
         #[automatically_derived]
         impl ::knative_conditions::ConditionType for #name {
+            #[inline]
             fn happy() -> Self {
                 #name::#happy
             }
 
+            #[inline]
             fn dependents() -> &'static [Self] {
                 &[#(#name::#dependents),*]
             }

--- a/knative/src/duck/v1/source_types.rs
+++ b/knative/src/duck/v1/source_types.rs
@@ -209,7 +209,9 @@ mod test {
         let mut status = MyCustomStatus {
             source_status: SourceStatus::default()
         };
-        status.source_status.mark_sink("http://url".parse().unwrap());
+        let uri = "http://url".parse::<url::Url>().unwrap();
+        status.source_status.mark_sink(uri.clone());
+        assert_eq!(status.source_status.sink_uri, Some(uri));
     }
 
     #[test]
@@ -296,6 +298,8 @@ mod test {
         let mut status = MyCustomStatus {
             source_status: SourceStatus::default()
         };
-        status.mark_sink("http://url".parse().unwrap());
+        let uri = "http://url".parse::<url::Url>().unwrap();
+        status.mark_sink(uri.clone());
+        assert_eq!(status.source_status.sink_uri, Some(uri));
     }
 }

--- a/knative/src/duck/v1/source_types.rs
+++ b/knative/src/duck/v1/source_types.rs
@@ -31,7 +31,8 @@ pub struct Destination {
     /// Ref points to an Addressable.
     #[serde(rename = "ref")]
     ref_: Option<KReference>,
-    /// URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
+    /// URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI.
+    /// Relative URIs will be resolved using the base URI retrieved from Ref.
     pub uri: Option<url::Url>,
 }
 

--- a/knative/src/duck/v1/source_types.rs
+++ b/knative/src/duck/v1/source_types.rs
@@ -212,6 +212,7 @@ mod test {
         let uri = "http://url".parse::<url::Url>().unwrap();
         status.source_status.mark_sink(uri.clone());
         assert_eq!(status.source_status.sink_uri, Some(uri));
+        assert_eq!(status.manager().get_condition(MyCondition::SinkProvided).map(|c| c.is_true()), Some(true))
     }
 
     #[test]
@@ -301,5 +302,6 @@ mod test {
         let uri = "http://url".parse::<url::Url>().unwrap();
         status.mark_sink(uri.clone());
         assert_eq!(status.source_status.sink_uri, Some(uri));
+        assert_eq!(status.manager().get_condition(MyCondition::SinkProvided).map(|c| c.is_true()), Some(true))
     }
 }

--- a/knative/src/duck/v1/source_types.rs
+++ b/knative/src/duck/v1/source_types.rs
@@ -177,7 +177,7 @@ mod test {
     }
 
     #[test]
-    fn can_update_sink() {
+    fn can_manage_sink() {
         let mut status = MyStatus {
             source_status: SourceStatus::default()
         };
@@ -205,7 +205,7 @@ mod test {
     }
 
     #[test]
-    fn can_update_custom_sink() {
+    fn can_manage_sink_on_source_status() {
         let mut status = MyCustomStatus {
             source_status: SourceStatus::default()
         };
@@ -249,17 +249,98 @@ mod test {
     }
 
     #[test]
-    fn can_update_custom_conditions() {
+    fn can_manage_custom_conditions() {
         let mut status = MyCustomStatus {
             source_status: SourceStatus::default()
         };
         let s = &mut status.source_status;
+
+        // Using MyConditionManager methods yields the same result as ConditionManager methods
+        s.mark_important();
+        s.mark_unimportant_with_reason(
+            "NotImportant",
+            Some("More information on Unimportant".into())
+        );
+        let old_conditions = s.conditions().clone();
+
+        s.manager().mark_true(MyCondition::Important);
         s.manager()
             .mark_true_with_reason(
                 MyCondition::Unimportant,
                 "NotImportant",
                 Some("More information on Unimportant".into())
         );
+        assert_eq!(old_conditions, *s.conditions());
         assert_eq!(s.is_ready(), false);
+
+        // Use of this function is discouraged because it does not guarantee that the sink has been
+        // set on SourceStatus, but you may choose to handle sink_uri yourself.
+        MyConditionManager::mark_sinkprovided(s);
+        assert_eq!(s.is_ready(), true);
+    }
+
+    impl ConditionAccessor<MyCondition> for MyCustomStatus {
+        fn conditions(&mut self) -> &mut Conditions<MyCondition> {
+            self.source_status.conditions()
+        }
+    }
+
+    impl SinkManager<MyCondition> for MyCustomStatus {
+        fn source_status(&mut self) -> &mut SourceStatus<MyCondition> {
+            &mut self.source_status
+        }
+    }
+
+    #[test]
+    fn can_manage_sink_on_custom_status() {
+        let mut status = MyCustomStatus {
+            source_status: SourceStatus::default()
+        };
+        status.mark_sink("http://url".parse().unwrap());
+    }
+
+    #[test]
+    fn can_init_with_custom_condition_state() {
+        use knative_conditions::{Condition, ConditionStatus};
+
+        let mut status = MyCustomStatus {
+            source_status: SourceStatus {
+                status: Status {
+                    conditions: Some(Conditions::with_conditions(vec![
+                        Condition {
+                            type_: MyCondition::Ready,
+                            status: ConditionStatus::True,
+                            ..Default::default()
+                        }
+                    ])),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        };
+
+        status.mark_sink("http://url".parse().unwrap());
+    }
+
+    #[test]
+    #[should_panic]
+    fn fails_to_init_with_improper_custom_condition_state() {
+        use knative_conditions::{Condition, ConditionStatus};
+
+        let _status = MyCustomStatus {
+            source_status: SourceStatus {
+                status: Status {
+                    conditions: Some(Conditions::with_conditions(vec![
+                        Condition {
+                            type_: MyCondition::Unimportant,
+                            status: ConditionStatus::True,
+                            ..Default::default()
+                        }
+                    ])),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        };
     }
 }

--- a/knative/src/duck/v1/source_types.rs
+++ b/knative/src/duck/v1/source_types.rs
@@ -298,49 +298,4 @@ mod test {
         };
         status.mark_sink("http://url".parse().unwrap());
     }
-
-    #[test]
-    fn can_init_with_custom_condition_state() {
-        use knative_conditions::{Condition, ConditionStatus};
-
-        let mut status = MyCustomStatus {
-            source_status: SourceStatus {
-                status: Status {
-                    conditions: Some(Conditions::with_conditions(vec![
-                        Condition {
-                            type_: MyCondition::Ready,
-                            status: ConditionStatus::True,
-                            ..Default::default()
-                        }
-                    ])),
-                    ..Default::default()
-                },
-                ..Default::default()
-            }
-        };
-
-        status.mark_sink("http://url".parse().unwrap());
-    }
-
-    #[test]
-    #[should_panic]
-    fn fails_to_init_with_improper_custom_condition_state() {
-        use knative_conditions::{Condition, ConditionStatus};
-
-        let _status = MyCustomStatus {
-            source_status: SourceStatus {
-                status: Status {
-                    conditions: Some(Conditions::with_conditions(vec![
-                        Condition {
-                            type_: MyCondition::Unimportant,
-                            status: ConditionStatus::True,
-                            ..Default::default()
-                        }
-                    ])),
-                    ..Default::default()
-                },
-                ..Default::default()
-            }
-        };
-    }
 }

--- a/knative/src/duck/v1/status_types.rs
+++ b/knative/src/duck/v1/status_types.rs
@@ -64,7 +64,7 @@ mod test {
         status.mark_somethingelse();
         assert_eq!(status.is_ready(), true);
 
-        // marking non_dependent status as not true does not make status ready
+        // marking non_dependent status as not true does not make status not ready
         status.mark_not_somethingelse("NotSomethingElse", None);
         assert_eq!(status.is_ready(), true);
 

--- a/knative/src/duck/v1/status_types.rs
+++ b/knative/src/duck/v1/status_types.rs
@@ -88,11 +88,10 @@ mod test {
         let _status = CustomStatus {
             status: Status {
                 conditions: Some(Conditions::with_conditions(vec![
-                    Condition {
-                        type_: CustomCondition::Succeeded,
-                        status: ConditionStatus::True,
-                        ..Default::default()
-                    }
+                    Condition::with_status(
+                        CustomCondition::Succeeded,
+                        ConditionStatus::True
+                    )
                 ])),
                 ..Default::default()
             }
@@ -107,11 +106,10 @@ mod test {
         let _status = CustomStatus {
             status: Status {
                 conditions: Some(Conditions::with_conditions(vec![
-                    Condition {
-                        type_: CustomCondition::SomethingElse,
-                        status: ConditionStatus::True,
-                        ..Default::default()
-                    }
+                    Condition::with_status(
+                        CustomCondition::SomethingElse,
+                        ConditionStatus::True
+                    )
                 ])),
                 ..Default::default()
             }

--- a/knative/src/duck/v1/status_types.rs
+++ b/knative/src/duck/v1/status_types.rs
@@ -80,4 +80,41 @@ mod test {
         status.mark_unknown();
         assert_eq!(status.is_ready(), false);
     }
+
+    #[test]
+    fn can_init_with_custom_condition_state() {
+        use knative_conditions::{Condition, ConditionStatus};
+
+        let _status = CustomStatus {
+            status: Status {
+                conditions: Some(Conditions::with_conditions(vec![
+                    Condition {
+                        type_: CustomCondition::Succeeded,
+                        status: ConditionStatus::True,
+                        ..Default::default()
+                    }
+                ])),
+                ..Default::default()
+            }
+        };
+    }
+
+    #[test]
+    #[should_panic]
+    fn fails_to_init_with_improper_custom_condition_state() {
+        use knative_conditions::{Condition, ConditionStatus};
+
+        let _status = CustomStatus {
+            status: Status {
+                conditions: Some(Conditions::with_conditions(vec![
+                    Condition {
+                        type_: CustomCondition::SomethingElse,
+                        status: ConditionStatus::True,
+                        ..Default::default()
+                    }
+                ])),
+                ..Default::default()
+            }
+        };
+    }
 }


### PR DESCRIPTION
# More Condition Tests

Examples of managing a non-source status, initializing status with custom conditions, implementing `ConditionAccessor` on your own Status types.

Derives `PartialEq` on `Conditions`.
