### PR TITLE
Use Enumset for ConditionType Dependents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "enumset"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4799cdb24d48f1f8a7a98d06b7fde65a85a2d1e42b25a889f5406aa1fbefe074"
+dependencies = [
+ "enumset_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea83a3fbdc1d999ccfbcbee717eab36f8edf2d71693a23ce0d7cca19e085304c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +512,7 @@ name = "knative"
 version = "0.1.1"
 dependencies = [
  "chrono",
+ "enumset",
  "k8s-openapi",
  "knative-conditions",
  "knative-derive",
@@ -506,6 +529,7 @@ name = "knative-conditions"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "enumset",
  "schemars",
  "serde",
  "serde_json",
@@ -515,6 +539,7 @@ dependencies = [
 name = "knative-derive"
 version = "0.1.0"
 dependencies = [
+ "enumset",
  "knative-conditions",
  "proc-macro2",
  "quote",

--- a/knative-conditions/Cargo.toml
+++ b/knative-conditions/Cargo.toml
@@ -9,6 +9,7 @@ description = "Knative status condition types and management."
 
 [dependencies]
 chrono = { version = "0.4.19", features = ["serde"] }
+enumset = { version = "1.0.11", features = ["serde"] }
 schemars = { version = "0.8.10", features = ["chrono"] }
 serde = "1.0.140"
 

--- a/knative-conditions/src/lib.rs
+++ b/knative-conditions/src/lib.rs
@@ -382,10 +382,8 @@ impl<'a, C: ConditionType> ConditionManager<'a, C> {
         // set happy condition to false if another dependent is false, otherwise set happy
         // condition to unknown if this condition is a dependent
         if let Some(dependent) = self.find_unhappy_dependent() {
-            if dependent.is_false() {
-                if !self.get_top_level_condition().is_false() {
-                    self.mark_false(C::happy(), reason, message);
-               }
+            if dependent.is_false() && self.is_happy() {
+                self.mark_false(C::happy(), reason, message);
             }
         } else if condition_type.is_terminal() {
            self.conditions.mark_unknown(C::happy(), reason.to_string(), message);

--- a/knative-conditions/src/lib.rs
+++ b/knative-conditions/src/lib.rs
@@ -208,15 +208,11 @@ impl<C: ConditionType> Conditions<C> {
             conditions.iter().any(|c| c.type_ == C::happy()),
             "Conditions must be initialized with the happy ConditionType"
         );
-        conditions.iter()
-            .fold(EnumSet::new(), |mut acc, c| {
-                assert!(
-                    !acc.contains(c.type_),
-                    "ConditionType must be unique to each Condition"
-                );
-                acc.insert(c.type_);
-                acc
-            });
+        assert_eq!(
+            EnumSet::from_iter(conditions.iter().map(|c| c.type_)).len(),
+            conditions.len(),
+            "ConditionType must be unique to each Condition"
+        );
         Conditions(conditions)
     }
 

--- a/knative-conditions/src/lib.rs
+++ b/knative-conditions/src/lib.rs
@@ -5,8 +5,7 @@ use std::fmt::Debug;
 
 /// Enums that implement [`ConditionType`] can be used to differentiate [`Condition`]
 /// and describe the state of the resource.
-pub trait ConditionType: Default + Debug + EnumSetType
-where Self: 'static {
+pub trait ConditionType: Default + Debug + EnumSetType {
     /// The top-level variant that determines overall readiness of the resource.
     fn happy() -> Self;
 

--- a/knative-derive/Cargo.toml
+++ b/knative-derive/Cargo.toml
@@ -19,3 +19,4 @@ quote = "1.0.20"
 syn = { version = "1.0.98", features = ["extra-traits"] }
 knative-conditions = { path = "../knative-conditions", version = "0.1.0" }
 proc-macro2 = "1.0.42"
+enumset = { version = "1.0.11", features = ["serde"] }

--- a/knative-derive/src/inner.rs
+++ b/knative-derive/src/inner.rs
@@ -116,8 +116,8 @@ pub fn inner_derive(ast: DeriveInput) -> Result<TokenStream> {
             }
 
             #[inline]
-            fn dependents() -> &'static [Self] {
-                &[#(#name::#dependents),*]
+            fn dependents() -> ::enumset::EnumSet<Self> {
+                ::enumset::enum_set!(#(#name::#dependents)|*)
             }
         }
 

--- a/knative-derive/src/lib.rs
+++ b/knative-derive/src/lib.rs
@@ -17,8 +17,9 @@ const REQUIRED_VARIANTS: [&str; 2] = ["Ready", "Succeeded"];
 /// # Example
 /// ```rust
 /// use knative_derive::ConditionType;
+/// use enumset::EnumSetType;
 ///
-/// #[derive(ConditionType, Debug, Copy, Clone, PartialEq)]
+/// #[derive(ConditionType, EnumSetType, Debug)]
 /// enum MyCondition {
 ///   // First condition must be Ready or Succeeded
 ///   Ready,

--- a/knative-derive/tests/test.rs
+++ b/knative-derive/tests/test.rs
@@ -1,8 +1,9 @@
 use knative_derive::ConditionType;
 use knative_conditions::ConditionType as _;
 use knative_conditions::{ConditionAccessor, Conditions};
+use enumset::EnumSetType;
 
-#[derive(ConditionType, Copy, Clone, Debug, PartialEq)]
+#[derive(ConditionType, EnumSetType, Debug)]
 enum MyCondition {
     Ready,
     #[dependent]
@@ -27,7 +28,7 @@ fn variant_functions_exist() {
 
 #[test]
 fn has_dependents() {
-    assert_eq!([MyCondition::SinkProvided], MyCondition::dependents());
+    assert_eq!(MyCondition::SinkProvided, MyCondition::dependents());
 }
 
 #[test]

--- a/knative/Cargo.toml
+++ b/knative/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"
 url = { version = "2.2.2", features = ["serde"] }
+enumset = { version = "1.0.11", features = ["serde"] }
 
 [dev-dependencies]
 kube = { version = "0.70.0", features = ["derive", "runtime", "client"] }

--- a/knative/src/duck/v1/source_types.rs
+++ b/knative/src/duck/v1/source_types.rs
@@ -3,9 +3,10 @@ use super::{
     knative_reference::KReference,
     status_types::Status,
 };
-use knative_conditions::{ConditionAccessor, Conditions};
 use crate::derive::ConditionType;
 use crate::error::{DiscoveryError, Error};
+use knative_conditions::{ConditionAccessor, Conditions};
+use enumset::EnumSetType;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -104,7 +105,7 @@ pub struct CloudEventAttributes {
 ///
 /// Custom conditions should implement [`SourceConditionType`] in order to be used by
 /// [`SourceStatus`].
-#[derive(ConditionType, Deserialize, Serialize, Copy, Clone, Debug, JsonSchema, PartialEq)]
+#[derive(ConditionType, EnumSetType, Deserialize, Serialize, Debug, JsonSchema)]
 pub enum SourceCondition {
     Ready,
     /// A [`sink_uri`] has been set on the resource.
@@ -185,7 +186,7 @@ mod test {
         status.source_status.mark_sink("http://url".parse().unwrap());
     }
 
-    #[derive(ConditionType, Clone, Copy, Debug, PartialEq)]
+    #[derive(ConditionType, EnumSetType, Debug)]
     enum MyCondition {
         Ready,
         #[dependent]

--- a/knative/src/duck/v1/status_types.rs
+++ b/knative/src/duck/v1/status_types.rs
@@ -38,8 +38,10 @@ impl<C: ConditionType> ConditionAccessor<C> for Status<C> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use knative_derive::ConditionType;
+    use enumset::EnumSetType;
 
-    #[derive(knative_derive::ConditionType, Copy, Clone, Debug, PartialEq)]
+    #[derive(ConditionType, EnumSetType, Debug)]
     enum CustomCondition {
         Succeeded,
         SomethingElse

--- a/knative/src/lib.rs
+++ b/knative/src/lib.rs
@@ -11,4 +11,5 @@ pub mod conditions {
 
 pub mod derive {
     pub use knative_derive::ConditionType;
+    pub use enumset::EnumSetType;
 }


### PR DESCRIPTION
# Use EnumSet for ConditionType Dependents

This change brings two benefits at the cost of an additional dependency:

1. Avoiding `String` allocations and hashing [in the assert](https://github.com/rusty-jules/knative-rs/blob/8deb385779e9a14d18f4926390d76d65d1ac77cb/knative-conditions/src/lib.rs#L209) on unique `ConditionTypes` in `Conditions::with_conditions`
2. Enforcing that the dependents returned by `ConditionType::dependents` is a set, which is not currently possible since we accept an `&'static [Self]` slice

`EnumSetType` also derives `Clone`, `Copy`, and `PartialEq` automatically, which we currently require anyways, so the number of derive attributes actually goes down.
